### PR TITLE
CI to validate image generation at each push

### DIFF
--- a/.github/workflows/valid-image-generation-test.yml
+++ b/.github/workflows/valid-image-generation-test.yml
@@ -1,0 +1,49 @@
+name: Test if current code can generate a valid image
+
+on: [push]
+
+env:
+   REGISTRY: ghcr.io
+   DOCKER_IMAGE_NAME: ${{ github.repository }}
+   URL_AUTH_SERVICE: localhost:8090/authToken
+
+
+jobs:
+  test-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lower case DOCKER_IMAGE_NAME
+        run: echo "DOCKER_IMAGE_NAME=$(echo $DOCKER_IMAGE_NAME | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Build Docker image
+        run: docker build -t $REGISTRY/$DOCKER_IMAGE_NAME .
+
+      - name: Create .env file
+        run: |
+          echo "URL_AUTH_SERVICE=$URL_AUTH_SERVICE" > .env
+
+      - name: Lower case DOCKER_IMAGE_NAME
+        run: echo "DOCKER_IMAGE_NAME=$(echo $DOCKER_IMAGE_NAME | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Run Docker container
+        run: |
+          (timeout 30s docker run --env-file "$(pwd)/.env" $REGISTRY/$DOCKER_IMAGE_NAME) ||
+          if [ $? -eq 124 ]; then
+            echo "OK, timeout error is acceptable."
+          else
+            exit $?
+          fi


### PR DESCRIPTION
The previous Flow for updating the image was somehow flawed it would really only on the developer to test the image.  
After merged to the main branch, the image would be updated in the GitHub Packages and only then tested. If any error  
passed the developer the image would be updated with error.  

Another important remark is that the automated test should not cause the pipeline to crash. However, relying solely on the attention of developers and reviewers to read the job's log is an unreliable practice.



One exemple of how the job would fail: https://github.com/GeoSales-Evolution/multi-tenant-uploader/pull/33/checks